### PR TITLE
Add support for ES6 classes

### DIFF
--- a/lib/di.js
+++ b/lib/di.js
@@ -1,10 +1,7 @@
 'use strict'
 
 Function.prototype.ourTinyConstructor = function(argArray) {
-    var constr = this;
-    var inst = Object.create(constr.prototype);
-    constr.apply(inst, argArray);
-    return inst;
+    return Reflect.construct(this, argArray);
 };
 
 const CustomError = function (code, message) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "author": "Vladyslav Litovka <vlad.litovka@gmail.com>",
   "license": "Apache 2",
   "engines": {
-    "node": ">=4.2.6"
+    "node": ">=6.0.0"
   }
 }

--- a/test/config.json
+++ b/test/config.json
@@ -21,6 +21,12 @@
       "new":      true,
       "store":    false,
       "args":     ["FS", "UTIL", "DI"]
+    },
+    "DEPENDENCY5": {
+      "require":  "lib/dependency5.js",
+      "new":      true,
+      "store":    false,
+      "args":     ["FS", "UTIL", "DI"]
     }
   },
   "test": {

--- a/test/lib/dependency5.js
+++ b/test/lib/dependency5.js
@@ -1,0 +1,19 @@
+class Dependency5 {
+    constructor(fs, util, di) {
+        this.test = false;
+
+        this.getFs = function () {
+            return fs;
+        };
+
+        this.getUtil = function () {
+            return util;
+        };
+
+        this.getDi = function () {
+            return di;
+        };
+    };
+}
+
+module.exports = Dependency5;

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,13 @@ describe('DI', () => {
         expect(instance.get.bind(instance, 'DEPENDENCY4')).to.not.throw(Error);
         expect(instance.get('DEPENDENCY4').getFs()).to.deep.equal(fs);
         expect(instance.get('DEPENDENCY4').getUtil()).to.deep.equal(util);
-        expect(instance.get.bind(instance, 'DEPENDENCY5')).to.throw(Error);
+        done();
+    });
+
+    it ('checking retrieval of dependency from other scope #2', (done) => {
+        expect(instance.get.bind(instance, 'DEPENDENCY5')).to.not.throw(Error);
+        expect(instance.get('DEPENDENCY5').getFs()).to.deep.equal(fs);
+        expect(instance.get('DEPENDENCY5').getUtil()).to.deep.equal(util);
         done();
     });
 
@@ -76,6 +82,11 @@ describe('DI', () => {
 
     it ('Should handle DI dependency', (done) => {
         expect(instance.get('DEPENDENCY4').getDi()).to.deep.equal(instance);
+        done();
+    });
+
+    it ('Should handle DI dependency #2', (done) => {
+        expect(instance.get('DEPENDENCY5').getDi()).to.deep.equal(instance);
         done();
     });
 });


### PR DESCRIPTION
This fix adds support for ES5 classes with dependencies. The current implementation doesn't support ES6 classes with dependencies and throws an error like "Class constructor Dependency5 cannot be invoked without 'new'"